### PR TITLE
Assistant checkpoint: Fix light mode styling issues on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,7 +71,7 @@ export default function HomePage() {
       </section>
 
       {/* Stats Section */}
-      <section className="py-16 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-700">
+      <section className="py-16 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <StatsCards 
             stats={[
@@ -85,7 +85,7 @@ export default function HomePage() {
       </section>
 
       {/* Features Section */}
-      <section className="py-20 bg-gray-50 dark:academic-bg">
+      <section className="py-20 bg-white dark:academic-bg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4" style={{ fontFamily: 'Playfair Display, Georgia, serif' }}>
@@ -164,7 +164,7 @@ export default function HomePage() {
       {/* Mission Section */}
       <section className="py-20 bg-gray-50 dark:academic-bg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="bg-gradient-to-br from-orange-500 to-orange-600 text-white text-center rounded-xl p-12 dark:content-section">
+          <div className="bg-gradient-to-br from-orange-500 to-orange-600 text-white text-center rounded-xl p-12">
             <Heart className="w-16 h-16 mx-auto mb-6 text-orange-100" />
             <h2 className="text-4xl font-bold mb-6" style={{ fontFamily: 'Playfair Display, Georgia, serif' }}>
               Our Mission

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -19,7 +19,7 @@ export default function Navbar() {
   const pathname = usePathname();
 
   return (
-    <nav className="bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b border-amber-100 dark:border-gray-700 sticky top-0 z-50">
+    <nav className="bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
@@ -28,7 +28,7 @@ export default function Navbar() {
               <div className="w-8 h-8 bg-gradient-to-br from-amber-500 to-orange-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">ST</span>
               </div>
-              <span className="text-2xl font-bold text-amber-700 dark:text-amber-400 serif-text">
+              <span className="text-2xl font-bold text-orange-600 dark:text-amber-400 serif-text">
                 Sanatan Timeline
               </span>
             </div>

--- a/src/components/ui/StatsCards.tsx
+++ b/src/components/ui/StatsCards.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 interface StatItem {
@@ -15,17 +14,17 @@ export default function StatsCards({ stats }: StatsCardsProps) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 my-12">
       {stats.map((stat, index) => (
-        <div key={index} className="stats-card group">
+        <div key={index} className="bg-white dark:stats-card border border-gray-200 dark:border-transparent rounded-lg p-6 hover:shadow-lg hover:border-orange-300 dark:hover:shadow-xl transition-all duration-300 text-center">
           <div className="text-center">
-            <div className="stats-number">
+            <div className="text-3xl font-bold text-orange-600 dark:stats-number mb-2">
               {stat.number}
               {stat.suffix && (
                 <span className="text-amber-400 text-xl ml-1">{stat.suffix}</span>
               )}
             </div>
-            <div className="stats-label">{stat.label}</div>
+            <div className="text-sm font-medium text-gray-600 dark:stats-label uppercase tracking-wide">{stat.label}</div>
           </div>
-          
+
           {/* Subtle glow effect */}
           <div className="absolute inset-0 bg-gradient-to-r from-amber-500/5 via-transparent to-amber-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-2xl pointer-events-none"></div>
         </div>


### PR DESCRIPTION
Assistant generated file changes:
- src/app/page.tsx: Fix light mode styling for homepage sections, Fix light mode styling for features section, Fix light mode styling for mission section
- src/components/ui/StatsCards.tsx: Fix light mode styling for stats cards Fix light mode styling for stats cards
Fix stats number styling for light mode
Fix light mode styling for stats cards
Fix stats number styling for light mode
Fix stats label styling for light mode
- src/components/layout/Navbar.tsx: Ensure navbar uses proper light/dark mode classes, Fix logo text color for light mode

---

User prompt:

dark mode is still coming in the ligh mode for homeoage, especially the navbar, fix this

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 52e36980-fa02-40fe-a936-6f012bac90fc